### PR TITLE
add matched tag comment to TypeInfo

### DIFF
--- a/parsing.go
+++ b/parsing.go
@@ -35,6 +35,7 @@ type TypeInfo struct {
 	FileInfo *FileInfo
 	GenDecl  *ast.GenDecl
 	TypeSpec *ast.TypeSpec
+	Comment  *ast.Comment
 }
 type TypeInfos []*TypeInfo
 
@@ -137,6 +138,7 @@ func (pkg *PackageInfo) CollectTaggedTypeInfos(tag string) TypeInfos {
 
 	for _, t := range types {
 		if c := findAnnotation(t.Doc(), tag); c != nil {
+			t.Comment = c
 			ret = append(ret, t)
 		}
 	}

--- a/parsing_test.go
+++ b/parsing_test.go
@@ -58,6 +58,11 @@ func TestPackageInfoCollectTaggedTypeInfos(t *testing.T) {
 		}
 		t.Fatalf("unexpected: %d", len(tis))
 	}
+	for _, ti := range tis {
+		if ti.Comment.Text != "// +test" {
+			t.Fatalf("unexpected: %s", ti.Comment.Text)
+		}
+	}
 }
 
 func TestPackageInfoCollectTypeInfos(t *testing.T) {


### PR DESCRIPTION
以下のようにstructにタグを付けるときにオプションを渡してそのオプション使って
code generateを行いたいケースがあるので、マッチしたコメントをTypeInfoにいれる修正を行いました。

**example.go**:

``` go

//go:generate my_awesome_generator

//+table: person
type Person struct {
    ID uint64 `db:"id"`
    Name string  `db:"name"`
}
```

ご検討のほどよろしくお願いします :bow:
